### PR TITLE
Make digraph creation case insensitive

### DIFF
--- a/Common/DotGraphUtilities/DotGraph.cs
+++ b/Common/DotGraphUtilities/DotGraph.cs
@@ -18,7 +18,7 @@ namespace DotGraphUtilities
     {
         public static IDictionary<string, SortedSet<string>> LoadDependencyGraph(string targetFile)
         {
-            IDictionary<string, SortedSet<string>> result = new SortedDictionary<string, SortedSet<string>>();
+            IDictionary<string, SortedSet<string>> result = new SortedDictionary<string, SortedSet<string>>(StringComparer.InvariantCultureIgnoreCase);
 
             IEnumerable<string> validDigraphLines = ParseForValidDigraphLines(targetFile);
 

--- a/MsBuildProjectReferenceDependencyGraph/MSBPRDependencyGraph.cs
+++ b/MsBuildProjectReferenceDependencyGraph/MSBPRDependencyGraph.cs
@@ -6,6 +6,7 @@
 
 namespace MsBuildProjectReferenceDependencyGraph
 {
+    using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.IO;
@@ -26,7 +27,7 @@ namespace MsBuildProjectReferenceDependencyGraph
         internal static Dictionary<string, IEnumerable<string>> ResolveProjectReferenceDependencies(IEnumerable<string> targetProjects)
         {
             Stack<string> unresolvedProjects = new Stack<string>();
-            Dictionary<string, IEnumerable<string>> resolvedProjects = new Dictionary<string, IEnumerable<string>>();
+            Dictionary<string, IEnumerable<string>> resolvedProjects = new Dictionary<string, IEnumerable<string>>(StringComparer.InvariantCultureIgnoreCase);
 
             // Load up the initial projects to the stack
             foreach (string targetProject in targetProjects.Distinct())
@@ -279,7 +280,7 @@ namespace MsBuildProjectReferenceDependencyGraph
             );
 
             // Convert this into the Dictionary
-            Dictionary<string, IEnumerable<string>> result = new Dictionary<string, IEnumerable<string>>();
+            Dictionary<string, IEnumerable<string>> result = new Dictionary<string, IEnumerable<string>>(StringComparer.InvariantCultureIgnoreCase);
             foreach (KeyValuePair<string, IEnumerable<string>> kvp in resolvedAssemblyReferences)
             {
                 result.Add(kvp.Key, kvp.Value);
@@ -307,7 +308,7 @@ namespace MsBuildProjectReferenceDependencyGraph
             );
 
             // Convert this into the Dictionary
-            Dictionary<string, IEnumerable<string>> result = new Dictionary<string, IEnumerable<string>>();
+            Dictionary<string, IEnumerable<string>> result = new Dictionary<string, IEnumerable<string>>(StringComparer.InvariantCultureIgnoreCase);
             foreach (KeyValuePair<string, IEnumerable<string>> kvp in resolvedPackageReferences)
             {
                 result.Add(kvp.Key, kvp.Value);

--- a/ProcessParallelAbility/ProcessParallelAbility/ParallelAbility.cs
+++ b/ProcessParallelAbility/ProcessParallelAbility/ParallelAbility.cs
@@ -6,6 +6,7 @@
 
 namespace ProcessParallelAbility
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
 
@@ -40,7 +41,7 @@ namespace ProcessParallelAbility
         /// <returns>A structure in which the Key is the project and the value is the depth within the given dependency tree.</returns>
         internal static IDictionary<string, int> ResolveParallelTree(IDictionary<string, SortedSet<string>> dependencyTree)
         {
-            IDictionary<string, int> parallelBuildTree = new Dictionary<string, int>();
+            IDictionary<string, int> parallelBuildTree = new Dictionary<string, int>(StringComparer.InvariantCultureIgnoreCase);
 
             foreach (KeyValuePair<string, SortedSet<string>> dotGraphEntry in dependencyTree)
             {


### PR DESCRIPTION
We have a solution that has > 1500 projects that we're trying to assess how to break up. Due to the nature of how the solution and references are put together, there are some case differences. Windows doesn't care when compiling, but when doing the analysis, I find duplicate entries for the same csproj in the digraphs being generated.

This fix will allow digraphs to be generated with case insensitive comparison and meeting our needs. 